### PR TITLE
query dns over udp (the default in dns.py), rather than tcp

### DIFF
--- a/dnsq.py
+++ b/dnsq.py
@@ -173,12 +173,12 @@ def exec_query(hostname, record_type, ns_server=None):
             resolver = get_resolver()
             resolver.nameservers = [ns_server]
             try:
-                return resolver.query(hostname, record_type, tcp=True)
+                return resolver.query(hostname, record_type)
             except dns.exception.Timeout:
                 pass
 
         # if it's not specified or timed out then use default nameserver
-        return get_resolver().query(hostname, record_type, tcp=True)
+        return get_resolver().query(hostname, record_type)
 
     # in case of timeouts and socket errors return []
     except dns.exception.Timeout:


### PR DESCRIPTION
Hard-coding dns queries to go over tcp breaks the lookup in cases when the DNS is only available over udp. We stumbled on this while testing Flanker in development environment under VMware Fusion.