### PR TITLE
Filter out domains that return invalid DNS results

### DIFF
--- a/dnsq.py
+++ b/dnsq.py
@@ -87,6 +87,10 @@ def mx_hosts_for(hostname):
     except dns.name.EmptyLabel:
         retval = []
 
+    # filter out invalid queries (tld does not exist)
+    dns_attention_string = ''.join(['your-dns-needs-immediate-attention.', hostname , '.'])
+    retval = [s for s in retval if s != dns_attention_string]
+
     # strip ending . and filter None
     retval = [h.strip('.') for h in retval]
     return filter(lambda x: x, retval)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='dnsq',
-      version='1.1.4',
+      version='1.1.5',
       description='DNS Query Tool',
       long_description=open("README.rst").read(),
       author='Rackspace',


### PR DESCRIPTION
**Purpose**

With the recent expansion of Top Level Domains (TLD), querying an invalid TLD can often return a result like:

```bash
$ dig +short mx gmail
10 your-dns-needs-immediate-attention.gmail.
```

This result should be stripped out by dnsq.

**Implementation**

When querying a MX record, filter out results that match:

```
your-dns-needs-immediate-attention.*.
```